### PR TITLE
Add improvements to test-read_xfplate.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Imports:
     knitr,
     dplyr,
     purrr,
-    usethis
+    usethis,
+    here
 RoxygenNote: 7.2.1
 Depends: 
     R (>= 2.10)

--- a/tests/testthat/test-read_xfplate.R
+++ b/tests/testthat/test-read_xfplate.R
@@ -1,6 +1,5 @@
 # set working_directory  --------------------------------------------------------------
-root <- rprojroot::is_rstudio_project
-working_directory <- root$find_file()
+
 # columnnames 'Raw' --------------------------------------------------------------
 # Columnames of 'Raw' Seahorse Excel datasheet.
 xf_raw_columns_list <<- list("Measurement",
@@ -35,7 +34,7 @@ check_column_names <- function(df, df_columns_list){
 # testthat: Test 'Raw' data --------------------------------------------------------------
 test_that("Test 'Raw' data derived from Seahorse XFe96 analyser 'Raw' Excel datasheet.", {
   # check return
-  xf_raw <- expect_type(get_xf_raw(file.path(working_directory, paste("data-raw/seahorse_test_data.xlsx"))), "list")
+  xf_raw <- expect_type(get_xf_raw(here::here("data-raw", "seahorse_test_data.xlsx")), "list")
   # perform checks on the returned tibble (list)
   check_column_names(xf_raw, xf_raw_columns_list)
   expect_length(xf_raw, 21)


### PR DESCRIPTION
dit is de pull request voor de foutmelding die ik kreeg bij het builden  (devtools::build()) van het package lokaal op mijn computer. Blijkbaar was er bij geen / nodig. Misschien een mac/windows ding. Kan jij hier naar kijken, en onderzoeken of here::here() beter werkt?

Zelfde soort fout tijdens builden in 
line 184 van calculate_ocr.R 
#data
my_data_pbmc <<- load("/cloud/project/data/my_pbmc_data.rda")

Dit is een absoluut path, en de data was geignored dus kwam niet bij mij terecht. We hadden net besproken om de data en de data-raw folders met data files erin wel te delen via github